### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meta-memcache-socket"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 dependencies = [
  "atoi",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meta-memcache-socket"
-version = "0.2.0-beta.2"
+version = "0.2.0"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Motivation / Description
Release version 0.2.0 of the meta-memcache-socket crate, promoting it from beta status to stable.

## Changes introduced
- Bumped version from "0.2.0-beta.2" to "0.2.0" in Cargo.toml
- Updated corresponding version in Cargo.lock