### PR TITLE
security: pin rust-toolchain@stable to SHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - run: cargo test
 
   python-tests:


### PR DESCRIPTION
Manual pin for dtolnay/rust-toolchain@stable; pinact does not support branch/stable refs.

Made with [Cursor](https://cursor.com)